### PR TITLE
Upgrade `urllib3` to 1.24.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,6 @@ speaklater==1.3
 Sphinx==1.7.6
 sphinx-rtd-theme==0.4.1
 sphinxcontrib-websupport==1.1.0
-urllib3==1.22
+urllib3==1.24.1
 Werkzeug==0.12.2
 WTForms==2.1


### PR DESCRIPTION
Fixes security vulnerability introduced by versions older than 1.23
(CVE-2018-20060). Resolves #103.