### PR TITLE
View a Popular Network from Search Page

### DIFF
--- a/culturemesh/blueprints/search/controllers.py
+++ b/culturemesh/blueprints/search/controllers.py
@@ -14,10 +14,19 @@ from culturemesh.blueprints.search.constants import GO_TO_NETWORK_MAX_RETRIES
 from culturemesh.blueprints.search.constants import GO_TO_NETWORK_WAIT_SECS
 
 import time
+from random import choice
 
 search = Blueprint('search', __name__, template_folder='templates')
 
 MAX_SUGGESTIONS = 10
+
+
+@search.route("/popular", methods=['GET'])
+def go_to_popular_network():
+    c = Client(mock=False)
+    nets = c.get_popular_networks(MAX_SUGGESTIONS)
+    net = choice(nets)
+    return redirect(url_for('networks.network', id=str(net['id'])))
 
 @search.route("/", methods=['GET', 'POST'])
 def render_search_page():

--- a/culturemesh/blueprints/search/templates/search.html
+++ b/culturemesh/blueprints/search/templates/search.html
@@ -20,14 +20,23 @@
         <div class="my-2 py-1 row">
             <div class="cm-blurb">
                 <div class="container-fluid p-3">
-                    <div id="cm-search-blurb">
-                        Find people who
-                    </div>
-                    <div class="row p-3">
-                        {{ form.search_type() }}
-                    </div>
+                    <div class="d-flex justify-content-between">
+                        <div>
+                            <div id="cm-search-blurb">
+                            Find people who
+                            </div>
+                            <div class="row p-3">
+                                {{ form.search_type() }}
+                            </div>
 
-                    {{ form.hidden_tag() }}
+                            {{ form.hidden_tag() }}
+                        </div>
+                        <div class="row p-3">
+                            <a href="/search/popular" id="cm-search-button"
+                               class="my-2 btn btn-secondary btn-sm pr-3
+                               float-right">View A Recommended Network</a>
+                        </div>
+                    </div>
 
                     <div class="row p-3">
                         {{ form.origin_or_language(

--- a/culturemesh/client/client.py
+++ b/culturemesh/client/client.py
@@ -15,6 +15,7 @@ import os
 import json
 import datetime
 import config
+from random import randrange
 import culturemesh
 from culturemesh import app
 from difflib import SequenceMatcher
@@ -140,6 +141,8 @@ class Client(object):
 					return self._mock_get_networks(
 						query_params, body_params
 					)
+				elif path[1] == 'popular':
+					return self._mock_get_random_networks(query_params)
 				else:
 					network_id = int(path[1])
 					return self._mock_get_network(network_id)
@@ -429,6 +432,16 @@ class Client(object):
 				networks = sorted(networks, key=lambda x: x['search_rank'], reverse=True)
 			return networks
 
+	def _mock_get_random_networks(self, query_params):
+		num_nets = query_params['count']
+		nets = []
+		with open(NETWORK_DATA_LOC) as networks:
+			networks = json.load(networks)
+			while len(nets) < num_nets and len(nets) < len(networks):
+				i = randrange(0, len(networks))
+				if networks[i] not in nets:
+					nets.append(networks[i])
+		return nets
 
 	def _mock_get_network(self, network_id):
 		"""
@@ -661,6 +674,7 @@ from .networks import get_network_events
 from .networks import get_network_users
 from .networks import get_network_user_count
 from .networks import get_network_post_count
+from .networks import get_popular_networks
 
 # We may consider adding a wrapper around these assignments
 # below to introduce more specific features for the client.
@@ -712,3 +726,4 @@ Client.get_network_events = get_network_events
 Client.get_network_users = get_network_users
 Client.get_network_user_count = get_network_user_count
 Client.get_network_post_count = get_network_post_count
+Client.get_popular_networks = get_popular_networks

--- a/culturemesh/client/networks.py
+++ b/culturemesh/client/networks.py
@@ -6,9 +6,11 @@ from .client import Request
 
 ####################### GET methods #######################
 
+
 def ping_network(client):
     url = 'network/ping'
     return client._request(url, Request.GET)
+
 
 def get_networks(client,
                  count,
@@ -98,6 +100,7 @@ def get_network_users(client, networkId, count, max_id=None):
         query_params['max_id'] = max_id
     return client._request(url, Request.GET, query_params=query_params)
 
+
 def get_network_user_count(client, networkId):
     """
     :param client: the CultureMesh API client
@@ -108,6 +111,7 @@ def get_network_user_count(client, networkId):
     url = 'network/%s/user_count' % str(networkId)
     return client._request(url, Request.GET)
 
+
 def get_network_post_count(client, networkId):
     """
     :param client: the CultureMesh API client
@@ -117,6 +121,18 @@ def get_network_post_count(client, networkId):
     """
     url = 'network/%s/post_count' % str(networkId)
     return client._request(url, Request.GET)
+
+
+def get_popular_networks(client, numNets):
+    """Get a list of popular networks
+
+    :param client: the CultureMesh API client
+    :param numNets: The number of networks to include. Must be in (0, 30]
+    :return: List of networks as JSON
+    """
+    url = 'network/popular'
+    query_params = {'count': numNets}
+    return client._request(url, Request.GET, query_params=query_params)
 
 ####################### POST methods #######################
 ####################### PUT methods #######################

--- a/test/unit/client/test_networks.py
+++ b/test/unit/client/test_networks.py
@@ -2,6 +2,7 @@
 # Tests client/networks.py
 #
 
+import random
 from nose.tools import assert_true, assert_equal
 import test.unit.client.client_test_prep
 from culturemesh.client import Client
@@ -87,3 +88,27 @@ def test_get_network_users():
     registrations2 = c.get_network_users(2, 1, max_id="2017-02-28 11:53:30")
     assert_equal(registrations2[0]['join_date'], "2017-02-27 11:53:30")
     assert_equal(len(registrations2), 1)
+
+
+# For random.seed(1)
+expected_pop_nets = [
+    {'id': 1, 'location_cur': {'country_id': 1, 'region_id': 1, 'city_id': 2},
+     'location_origin': {'country_id': 1, 'region_id': 2, 'city_id': 3},
+     'language_origin': {'id': 2, 'name': 'entish', 'num_speakers': 10,
+                         'added': 0}, 'network_class': 0,
+     'date_added': '1990-11-23 15:31:51', 'img_link': 'img1.png'},
+    {'id': 2, 'location_cur': {'country_id': 2, 'region_id': 4, 'city_id': 6},
+     'location_origin': {'country_id': 1, 'region_id': 1, 'city_id': 1},
+     'language_origin': {'id': 3, 'name': 'valarin', 'num_speakers': 1000,
+                         'added': 0},
+     'network_class': 0, 'date_added': '1995-11-23 15:31:51',
+     'img_link': 'img2.png'}
+]
+
+
+def test_get_popular_networks():
+    c = Client(mock=True)
+    random.seed(1)
+    nets = c.get_popular_networks(2)
+
+    assert_equal(nets, expected_pop_nets)


### PR DESCRIPTION
Add a button to the search page that takes the user to a randomly chosen popular network. This will make it easier for new users to check out what the app has to offer without knowing a network to search for. Resolves #110.