### PR TITLE
Bugfix: Viewing Network when Signed In

### DIFF
--- a/culturemesh/blueprints/networks/controllers.py
+++ b/culturemesh/blueprints/networks/controllers.py
@@ -27,7 +27,7 @@ def network():
   id_network = request.args.get('id')
   c = Client(mock=False)
 
-  id_user = current_user.get_id()
+  id_user = current_user.id
   network_info = gather_network_info(id_network, id_user, c)
   upcoming_events = get_upcoming_events_by_network(c, id_network, 3)
 


### PR DESCRIPTION
Viewing a network, e.g. at `network/?id=1`, was failing because in the
networks controllers, we were getting the user ID with
`current_user.get_id()`. However, the `get_id()` method returns a
dictionary of the user object (as described in docstrings). Instead, we
want to use `current_user.id`.

This resolves #121.