### PR TITLE
Bugfix: Viewing Network When Logged-Out

### DIFF
--- a/culturemesh/blueprints/networks/controllers.py
+++ b/culturemesh/blueprints/networks/controllers.py
@@ -27,7 +27,7 @@ def network():
   id_network = request.args.get('id')
   c = Client(mock=False)
 
-  id_user = current_user.id
+  id_user = current_user.id if is_logged_in(current_user) else None
   network_info = gather_network_info(id_network, id_user, c)
   upcoming_events = get_upcoming_events_by_network(c, id_network, 3)
 


### PR DESCRIPTION
We did not correctly handle viewing networks when the user is logged
out. Before we try and get the user ID, we need to check that the user
is logged in, else no ID will be available.